### PR TITLE
[*] Use maps for env blocks

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: lint, install
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/charts/azure-janitor/Chart.yaml
+++ b/charts/azure-janitor/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-janitor
 type: application
 description: A Helm chart for azure-janitor
 home: https://github.com/webdevops/azure-janitor
-version: 1.0.4
+version: 1.0.5
 appVersion: 22.9.0
 keywords:
 - azure-janitor

--- a/charts/azure-janitor/ci/env-values.yaml
+++ b/charts/azure-janitor/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/azure-janitor/templates/deployment.yaml
+++ b/charts/azure-janitor/templates/deployment.yaml
@@ -45,19 +45,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
-{{- range $index, $val := .Values.secrets }}
-          - name: {{ $index | quote }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "azure-janitor.fullname" $ }}
-                key: {{ $index | quote }}
-{{- end }}
-{{ with .Values.env }}
-{{ toYaml . | nindent 12 }}
-{{end}}
-
+          {{- range $index, $val := .Values.secrets }}
+            - name: {{ $index | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "azure-janitor.fullname" $ }}
+                  key: {{ $index | quote }}
+          {{- end }}
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/azure-janitor/values.yaml
+++ b/charts/azure-janitor/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv:
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/azure-keyvault-exporter/Chart.yaml
+++ b/charts/azure-keyvault-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-keyvault-exporter
 type: application
 description: A Helm chart for azure-keyvault-exporter
 home: https://github.com/webdevops/azure-keyvault-exporter
-version: 1.0.1
+version: 1.0.2
 appVersion: 22.9.0
 keywords:
 - azure-keyvault-exporter

--- a/charts/azure-keyvault-exporter/ci/env-values.yaml
+++ b/charts/azure-keyvault-exporter/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/azure-keyvault-exporter/templates/deployment.yaml
+++ b/charts/azure-keyvault-exporter/templates/deployment.yaml
@@ -47,19 +47,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
-{{- range $index, $val := .Values.secrets }}
-          - name: {{ $index | quote }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "azure-keyvault-exporter.fullname" $ }}
-                key: {{ $index | quote }}
-{{- end }}
-{{ with .Values.env }}
-{{ toYaml . | nindent 12 }}
-{{end}}
-
+          {{- range $index, $val := .Values.secrets }}
+            - name: {{ $index | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "azure-keyvault-exporter.fullname" $ }}
+                  key: {{ $index | quote }}
+          {{- end }}
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/azure-keyvault-exporter/values.yaml
+++ b/charts/azure-keyvault-exporter/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv: []
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.1
+version: 1.0.2
 appVersion: 22.9.0
 keywords:
 - azure-metrics-exporter

--- a/charts/azure-metrics-exporter/ci/env-values.yaml
+++ b/charts/azure-metrics-exporter/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -47,19 +47,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
-{{- range $index, $val := .Values.secrets }}
-          - name: {{ $index | quote }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "azure-metrics-exporter.fullname" $ }}
-                key: {{ $index | quote }}
-{{- end }}
-{{ with .Values.env }}
-{{ toYaml . | nindent 12 }}
-{{end}}
-
+          {{- range $index, $val := .Values.secrets }}
+            - name: {{ $index | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "azure-metrics-exporter.fullname" $ }}
+                  key: {{ $index | quote }}
+          {{- end }}
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv: []
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.0.3
+version: 1.0.4
 appVersion: 22.9.1
 keywords:
 - azure-resourcemanager-exporter

--- a/charts/azure-resourcemanager-exporter/ci/env-values.yaml
+++ b/charts/azure-resourcemanager-exporter/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/azure-resourcemanager-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/deployment.yaml
@@ -47,19 +47,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
-{{- range $index, $val := .Values.secrets }}
-          - name: {{ $index | quote }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "azure-resourcemanager-exporter.fullname" $ }}
-                key: {{ $index | quote }}
-{{- end }}
-{{ with .Values.env }}
-{{ toYaml . | nindent 12 }}
-{{end}}
-
+          {{- range $index, $val := .Values.secrets }}
+            - name: {{ $index | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "azure-resourcemanager-exporter.fullname" $ }}
+                  key: {{ $index | quote }}
+          {{- end }}
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/azure-resourcemanager-exporter/values.yaml
+++ b/charts/azure-resourcemanager-exporter/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv: []
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/azure-scheduledevents-manager/Chart.yaml
+++ b/charts/azure-scheduledevents-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-scheduledevents-manager
 type: application
 description: A Helm chart for azure-scheduledevents-manager
 home: https://github.com/webdevops/azure-scheduledevents-manager
-version: 1.0.7
+version: 1.0.8
 appVersion: 22.9.0
 keywords:
   - azure-scheduledevents-manager

--- a/charts/azure-scheduledevents-manager/ci/env-values.yaml
+++ b/charts/azure-scheduledevents-manager/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/azure-scheduledevents-manager/templates/daemonset.yaml
+++ b/charts/azure-scheduledevents-manager/templates/daemonset.yaml
@@ -65,10 +65,13 @@ spec:
                   fieldPath: spec.nodeName
             - name: AZURE_ERROR_THRESHOLD
               value: "10"
-            {{- with .Values.env }}
-            {{ toYaml . | nindent 12 }}
-            {{- end}}
-
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/azure-scheduledevents-manager/values.yaml
+++ b/charts/azure-scheduledevents-manager/values.yaml
@@ -14,10 +14,8 @@ image:
   pullPolicy: IfNotPresent
 
 env: []
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/kube-pool-manager/Chart.yaml
+++ b/charts/kube-pool-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: kube-pool-manager
 type: application
 description: A Helm chart for kube-pool-manager
 home: https://github.com/webdevops/kube-pool-manager
-version: 1.0.7
+version: 1.0.8
 appVersion: 22.9.0
 keywords:
   - kube-pool-manager

--- a/charts/kube-pool-manager/ci/env-values.yaml
+++ b/charts/kube-pool-manager/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/kube-pool-manager/templates/deployment.yaml
+++ b/charts/kube-pool-manager/templates/deployment.yaml
@@ -51,7 +51,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
             - name: CONFIG
               value: /app/config.yaml
@@ -75,10 +74,13 @@ spec:
                   name: {{ template "kube-pool-manager.fullname" $ }}
                   key: {{ $index | quote }}
           {{- end }}
-          {{- with .Values.env }}
-          {{ toYaml . | nindent 12 }}
-          {{- end}}
-
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/kube-pool-manager/values.yaml
+++ b/charts/kube-pool-manager/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv: []
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}

--- a/charts/pagerduty-exporter/Chart.yaml
+++ b/charts/pagerduty-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: pagerduty-exporter
 type: application
 description: A Helm chart for pagerduty-exporter
 home: https://github.com/webdevops/pagerduty-exporter
-version: 1.0.2
+version: 1.0.3
 appVersion: 22.9.1
 keywords:
 - pagerduty-exporter

--- a/charts/pagerduty-exporter/ci/env-values.yaml
+++ b/charts/pagerduty-exporter/ci/env-values.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBUG: "true"
+
+extraEnv:
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace

--- a/charts/pagerduty-exporter/templates/deployment.yaml
+++ b/charts/pagerduty-exporter/templates/deployment.yaml
@@ -47,19 +47,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
 
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-
           env:
-{{- range $index, $val := .Values.secrets }}
-          - name: {{ $index | quote }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "pagerduty-exporter.fullname" $ }}
-                key: {{ $index | quote }}
-{{- end }}
-{{ with .Values.env }}
-{{ toYaml . | nindent 12 }}
-{{end}}
-
+          {{- range $index, $val := .Values.secrets }}
+            - name: {{ $index | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "pagerduty-exporter.fullname" $ }}
+                  key: {{ $index | quote }}
+          {{- end }}
+          {{- range $name, $value := .Values.env }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http-metrics

--- a/charts/pagerduty-exporter/values.yaml
+++ b/charts/pagerduty-exporter/values.yaml
@@ -17,10 +17,15 @@ minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
 env: {}
-  # - name: DEBUG
-  #   value: "true"
-  # - name: VERBOSE
-  #   value: "true"
+  # DEBUG: "true"
+  # VERBOSE: "true"
+
+extraEnv: []
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: redis-password
+  #       name: redis-config-0.0.2
 
 secretsEnableTemplateFunctions: false
 secrets: {}


### PR DESCRIPTION
#### What this PR does / why we need it

In helm, lists are not mergable. Currently, we embed the helm charts into an umbrella helm chart and want to provide default values, which can not be inherit if downstream values contains env variables.

#### Special notes for your reviewer

I bump the versions, if #1 is merged.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
