### PR TITLE
[*] Update selectorLabels for pods and remove podLabels

### DIFF
--- a/charts/azure-janitor/Chart.yaml
+++ b/charts/azure-janitor/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-janitor
 type: application
 description: A Helm chart for azure-janitor
 home: https://github.com/webdevops/azure-janitor
-version: 1.0.6
+version: 1.0.7
 # renovate: image=webdevops/azure-janitor
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-janitor/templates/_helpers.tpl
+++ b/charts/azure-janitor/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "azure-janitor.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-janitor/templates/deployment.yaml
+++ b/charts/azure-janitor/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "azure-janitor.labels" . | indent 8 }}
+{{ include "azure-janitor.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/azure-keyvault-exporter/Chart.yaml
+++ b/charts/azure-keyvault-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-keyvault-exporter
 type: application
 description: A Helm chart for azure-keyvault-exporter
 home: https://github.com/webdevops/azure-keyvault-exporter
-version: 1.0.3
+version: 1.0.4
 # renovate: image=webdevops/azure-keyvault-exporter
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-keyvault-exporter/templates/_helpers.tpl
+++ b/charts/azure-keyvault-exporter/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "azure-keyvault-exporter.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-keyvault-exporter/templates/deployment.yaml
+++ b/charts/azure-keyvault-exporter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "azure-keyvault-exporter.labels" . | indent 8 }}
+{{ include "azure-keyvault-exporter.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/azure-loganalytics-exporter/Chart.yaml
+++ b/charts/azure-loganalytics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-loganalytics-exporter
 type: application
 description: A Helm chart for azure-loganalytics-exporter
 home: https://github.com/webdevops/azure-loganalytics-exporter
-version: 1.0.1
+version: 1.0.2
 # renovate: image=webdevops/azure-loganalytics-exporter
 appVersion: 22.11.0
 keywords:

--- a/charts/azure-loganalytics-exporter/templates/_helpers.tpl
+++ b/charts/azure-loganalytics-exporter/templates/_helpers.tpl
@@ -49,9 +49,6 @@ app.kubernetes.io/part-of: {{ template "azure-loganalytics-exporter.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels }}
-{{- toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-loganalytics-exporter/templates/deployment.yaml
+++ b/charts/azure-loganalytics-exporter/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "azure-loganalytics-exporter.labels" . | nindent 8 }}
+        {{- include "azure-loganalytics-exporter.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.3
+version: 1.0.4
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-metrics-exporter/templates/_helpers.tpl
+++ b/charts/azure-metrics-exporter/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "azure-metrics-exporter.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "azure-metrics-exporter.labels" . | indent 8 }}
+{{ include "azure-metrics-exporter.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/azure-resourcegraph-exporter/Chart.yaml
+++ b/charts/azure-resourcegraph-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcegraph-exporter
 type: application
 description: A Helm chart for azure-resourcegraph-exporter
 home: https://github.com/webdevops/azure-resourcegraph-exporter
-version: 1.0.1
+version: 1.0.2
 # renovate: image=webdevops/azure-resourcegraph-exporter
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-resourcegraph-exporter/templates/_helpers.tpl
+++ b/charts/azure-resourcegraph-exporter/templates/_helpers.tpl
@@ -49,9 +49,6 @@ app.kubernetes.io/part-of: {{ template "azure-resourcegraph-exporter.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels }}
-{{- toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-resourcegraph-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "azure-resourcegraph-exporter.labels" . | nindent 8 }}
+        {{- include "azure-resourcegraph-exporter.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.1.0
+version: 1.1.1
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 22.11.0
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/_helpers.tpl
+++ b/charts/azure-resourcemanager-exporter/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "azure-resourcemanager-exporter.name" . }
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-resourcemanager-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "azure-resourcemanager-exporter.labels" . | indent 8 }}
+{{ include "azure-resourcemanager-exporter.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/azure-scheduledevents-manager/Chart.yaml
+++ b/charts/azure-scheduledevents-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-scheduledevents-manager
 type: application
 description: A Helm chart for azure-scheduledevents-manager
 home: https://github.com/webdevops/azure-scheduledevents-manager
-version: 1.0.9
+version: 1.0.10
 # renovate: image=webdevops/azure-scheduledevents-exporter
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-scheduledevents-manager/templates/_helpers.tpl
+++ b/charts/azure-scheduledevents-manager/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "azure-scheduledevents-manager.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/azure-scheduledevents-manager/templates/daemonset.yaml
+++ b/charts/azure-scheduledevents-manager/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "azure-scheduledevents-manager.labels" . | indent 8 }}
+{{ include "azure-scheduledevents-manager.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/kube-pool-manager/Chart.yaml
+++ b/charts/kube-pool-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: kube-pool-manager
 type: application
 description: A Helm chart for kube-pool-manager
 home: https://github.com/webdevops/kube-pool-manager
-version: 1.0.9
+version: 1.0.10
 # renovate: image=webdevops/kube-pool-manager
 appVersion: 22.9.0
 keywords:

--- a/charts/kube-pool-manager/templates/_helpers.tpl
+++ b/charts/kube-pool-manager/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "kube-pool-manager.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/kube-pool-manager/templates/deployment.yaml
+++ b/charts/kube-pool-manager/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "kube-pool-manager.labels" . | indent 8 }}
+{{ include "kube-pool-manager.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pagerduty-exporter/Chart.yaml
+++ b/charts/pagerduty-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: pagerduty-exporter
 type: application
 description: A Helm chart for pagerduty-exporter
 home: https://github.com/webdevops/pagerduty-exporter
-version: 1.1.0
+version: 1.1.1
 # renovate: image=webdevops/pagerduty-exporter
 appVersion: 22.12.0
 keywords:

--- a/charts/pagerduty-exporter/templates/_helpers.tpl
+++ b/charts/pagerduty-exporter/templates/_helpers.tpl
@@ -50,9 +50,6 @@ app.kubernetes.io/part-of: {{ template "pagerduty-exporter.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
-{{- end }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/charts/pagerduty-exporter/templates/deployment.yaml
+++ b/charts/pagerduty-exporter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "pagerduty-exporter.labels" . | indent 8 }}
+{{ include "pagerduty-exporter.selectorLabels" . | indent 8 }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

Remove `podLabels` from helpers.tpl as we are already adding podLabels in deployment/daemonset of all apps. Specifying pod labels right now giving helm compilation error, as podLabels are getting added two times under same hierarcy which is not allowed. 

Updating pod template labels from `.labels` -> `.selectorLabels` as helm won't be able to upgrade deployment/daemonset pods without deleting them whenever a helm chart version is updated.  Also, `selector` and `template.label` should have matching data in a deployment or daemonset manifest. 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
