### PR TITLE
[azure-metrics-exporter] Add path azure metrics exporter

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,13 +3,13 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.4
+version: 1.0.5
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 22.9.0
 keywords:
-- azure-metrics-exporter
+  - azure-metrics-exporter
 maintainers:
-- email: mblaschke82@gmail.com
-  name: mblaschke
+  - email: mblaschke82@gmail.com
+    name: mblaschke
 sources:
-- https://github.com/webdevops/azure-metrics-exporter/
+  - https://github.com/webdevops/azure-metrics-exporter/

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.1.0
+version: 1.0.8
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.7.0
 keywords:

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -16,6 +16,7 @@ spec:
   endpoints:
     - port: {{ $root.Values.service.portName }}
       scheme: {{ (default .scheme $monitor.scheme) }}
+      path: {{ (default .path $monitor.path) }}
     {{- with (default .basicAuth $monitor.basicAuth) }}
       basicAuth: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -1,5 +1,5 @@
 {{ $root := . }}
-{{ $monitor := .Values.prometheus.metricProbes }}
+{{ $monitorDefaults := .Values.prometheus.metricProbes.probeDefaults }}
 {{- range .Values.prometheus.metricProbes.probes }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -9,40 +9,40 @@ metadata:
   namespace: {{ template "azure-metrics-exporter.namespace" $root }}
   labels: {{ include "azure-metrics-exporter.labels" $root | indent 4 }}
 spec:
-  jobLabel: {{ default "app.kubernetes.io/name" $monitor.jobLabel }}
-  {{ include "servicemonitor.scrapeLimits" $monitor | indent 2 }}
+  jobLabel: {{ default "app.kubernetes.io/name" $monitorDefaults.jobLabel }}
+  {{ include "servicemonitor.scrapeLimits" $monitorDefaults | indent 2 }}
   selector:
     matchLabels: {{- include "azure-metrics-exporter.selectorLabels" $root | nindent 6 }}
   endpoints:
     - port: {{ $root.Values.service.portName }}
-      scheme: {{ (default .scheme $monitor.scheme) }}
-      path: {{ (default .path $monitor.path) }}
-    {{- with (default .basicAuth $monitor.basicAuth) }}
+      scheme: {{ (default .scheme $monitorDefaults.scheme) }}
+      path: {{ (default .path $monitorDefaults.path) }}
+    {{- with (default .basicAuth $monitorDefaults.basicAuth) }}
       basicAuth: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with (default .bearerTokenFile $monitor.bearerTokenFile) }}
+    {{- with (default .bearerTokenFile $monitorDefaults.bearerTokenFile) }}
       bearerTokenFile: {{ . }}
     {{- end }}
-    {{- with (default .tlsConfig $monitor.tlsConfig) }}
+    {{- with (default .tlsConfig $monitorDefaults.tlsConfig) }}
       tlsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with (default .proxyUrl $monitor.proxyUrl) }}
+    {{- with (default .proxyUrl $monitorDefaults.proxyUrl) }}
       proxyUrl: {{ . }}
     {{- end }}
-    {{- with (default .interval $monitor.interval) }}
+    {{- with (default .interval $monitorDefaults.interval) }}
       interval: {{ . }}
     {{- end }}
-    {{- with (default .scrapeTimeout $monitor.scrapeTimeout) }}
+    {{- with (default .scrapeTimeout $monitorDefaults.scrapeTimeout) }}
       scrapeTimeout: {{ . }}
     {{- end }}
-    {{- with (default .relabelings $monitor.relabelings) }}
+    {{- with (default .relabelings $monitorDefaults.relabelings) }}
       relabelings: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with (default .metricRelabelings $monitor.metricRelabelings) }}
+    {{- with (default .metricRelabelings $monitorDefaults.metricRelabelings) }}
       metricRelabelings: {{- toYaml . | nindent 8 }}
     {{- end }}
       params:
-        {{- with (merge .params $monitor.params) }}
+        {{- with (merge .params $monitorDefaults.params) }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -1,5 +1,5 @@
 {{ $root := . }}
-{{ $monitorDefaults := .Values.prometheus.metricProbes.probeDefaults }}
+{{ $monitorDefaults := .Values.prometheus.metricProbes }}
 {{- range .Values.prometheus.metricProbes.probes }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -171,46 +171,47 @@ prometheus:
 
   ## azure metrics probe scrapes
   metricProbes:
-    jobLabel: ""
+    probeDefaults:
+      jobLabel: ""
 
-    scheme: http
-    basicAuth: {}
-    bearerTokenFile:
-    tlsConfig: {}
-    path: /probe/metrics/list
+      scheme: http
+      basicAuth: {}
+      bearerTokenFile:
+      tlsConfig: {}
+      path: /probe/metrics/list
 
-    ## proxyUrl: URL of a proxy that should be used for scraping.
-    ##
-    proxyUrl: ""
+      ## proxyUrl: URL of a proxy that should be used for scraping.
+      ##
+      proxyUrl: ""
 
-    relabelings: []
-    metricRelabelings: []
-    interval: ""
-    scrapeTimeout: ""
+      relabelings: []
+      metricRelabelings: []
+      interval: ""
+      scrapeTimeout: ""
 
-    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-    ##
-    sampleLimit: 0
+      ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+      ##
+      sampleLimit: 0
 
-    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
-    ##
-    targetLimit: 0
+      ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+      ##
+      targetLimit: 0
 
-    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-    ##
-    labelLimit: 0
+      ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+      ##
+      labelLimit: 0
 
-    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-    ##
-    labelNameLengthLimit: 0
+      ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+      ##
+      labelNameLengthLimit: 0
 
-    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-    ##
-    labelValueLengthLimit: 0
+      ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+      ##
+      labelValueLengthLimit: 0
 
-    # global probe params (will be merged with probes[].params)
-    # and can act as defaults
-    params: {}
+      # global probe params (will be merged with probes[].params)
+      # and can act as defaults
+      params: {}
 
     probes: []
 #      - name: appgateway

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -16,11 +16,13 @@ replicas: 1
 minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
-env: {}
+env:
+  {}
   # DEBUG: "true"
   # VERBOSE: "true"
 
-extraEnv: []
+extraEnv:
+  []
   # - name: REDIS_PASSWORD
   #   valueFrom:
   #     secretKeyRef:
@@ -30,7 +32,6 @@ extraEnv: []
 secretsEnableTemplateFunctions: false
 secrets: {}
 # secretName: secretValue
-
 
 resources:
   limits:
@@ -118,15 +119,15 @@ netpol:
   egress:
     # DNS
     - ports:
-      - port: 53
-        protocol: TCP
+        - port: 53
+          protocol: TCP
     - ports:
-      - port: 53
-        protocol: UDP
+        - port: 53
+          protocol: UDP
     # HTTPS (Azure REST api)
     - ports:
-      - port: 443
-        protocol: TCP
+        - port: 443
+          protocol: TCP
 
 prometheus:
   monitor:
@@ -176,6 +177,7 @@ prometheus:
     basicAuth: {}
     bearerTokenFile:
     tlsConfig: {}
+    path: /probe/metrics/list
 
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
@@ -212,6 +214,7 @@ prometheus:
 
     probes: []
 #      - name: appgateway
+#        path: /probe/metrics/list
 #        params:
 #          name: ["azure_metrics_appgateway"]
 #          resourceType: ["Microsoft.Network/applicationGateways"]

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -16,13 +16,11 @@ replicas: 1
 minReadySeconds: 10
 terminationGracePeriodSeconds: 60
 
-env:
-  {}
+env: {}
   # DEBUG: "true"
   # VERBOSE: "true"
 
-extraEnv:
-  []
+extraEnv: []
   # - name: REDIS_PASSWORD
   #   valueFrom:
   #     secretKeyRef:
@@ -32,6 +30,7 @@ extraEnv:
 secretsEnableTemplateFunctions: false
 secrets: {}
 # secretName: secretValue
+
 
 resources:
   limits:
@@ -120,15 +119,15 @@ netpol:
   egress:
     # DNS
     - ports:
-        - port: 53
-          protocol: TCP
+      - port: 53
+        protocol: TCP
     - ports:
-        - port: 53
-          protocol: UDP
+      - port: 53
+        protocol: UDP
     # HTTPS (Azure REST api)
     - ports:
-        - port: 443
-          protocol: TCP
+      - port: 443
+        protocol: TCP
 
 prometheus:
   monitor:
@@ -172,51 +171,49 @@ prometheus:
 
   ## azure metrics probe scrapes
   metricProbes:
-    probeDefaults:
-      jobLabel: ""
+    jobLabel: ""
 
-      scheme: http
-      basicAuth: {}
-      bearerTokenFile:
-      tlsConfig: {}
-      path: /probe/metrics/list
+    scheme: http
+    path: /probe/metrics/list
+    basicAuth: {}
+    bearerTokenFile:
+    tlsConfig: {}
 
-      ## proxyUrl: URL of a proxy that should be used for scraping.
-      ##
-      proxyUrl: ""
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
 
-      relabelings: []
-      metricRelabelings: []
-      interval: ""
-      scrapeTimeout: ""
+    relabelings: []
+    metricRelabelings: []
+    interval: ""
+    scrapeTimeout: ""
 
-      ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-      ##
-      sampleLimit: 0
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
 
-      ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
-      ##
-      targetLimit: 0
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
 
-      ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-      ##
-      labelLimit: 0
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
 
-      ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-      ##
-      labelNameLengthLimit: 0
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
 
-      ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
-      ##
-      labelValueLengthLimit: 0
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
 
-      # global probe params (will be merged with probes[].params)
-      # and can act as defaults
-      params: {}
+    # global probe params (will be merged with probes[].params)
+    # and can act as defaults
+    params: {}
 
     probes: []
 #      - name: appgateway
-#        path: /probe/metrics/list
 #        params:
 #          name: ["azure_metrics_appgateway"]
 #          resourceType: ["Microsoft.Network/applicationGateways"]


### PR DESCRIPTION
#### What this PR does / why we need it

Currently, it is impossible to change the path for metrics probes.
It is using the default path `/metrics` that point on the azure-metrics-exporter pod and not on the metrics fetched from Azure.
The default path is now `/probe/metrics/list` and it is possible to override it, if needed.

#### Which issue this PR fixes

- fixes #15

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
