### PR TITLE
Make it possible to not create service accounts for charts

### DIFF
--- a/charts/azure-janitor/Chart.yaml
+++ b/charts/azure-janitor/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-janitor
 type: application
 description: A Helm chart for azure-janitor
 home: https://github.com/webdevops/azure-janitor
-version: 1.0.7
+version: 1.0.8
 # renovate: image=webdevops/azure-janitor
 appVersion: 22.9.0
 keywords:

--- a/charts/azure-janitor/templates/serviceaccount.yaml
+++ b/charts/azure-janitor/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "azure-janitor.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/azure-janitor/values.yaml
+++ b/charts/azure-janitor/values.yaml
@@ -71,6 +71,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: azure-janitor
   labels: {}
   annotations: {}

--- a/charts/azure-keyvault-exporter/Chart.yaml
+++ b/charts/azure-keyvault-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-keyvault-exporter
 type: application
 description: A Helm chart for azure-keyvault-exporter
 home: https://github.com/webdevops/azure-keyvault-exporter
-version: 1.0.6
+version: 1.0.7
 # renovate: image=webdevops/azure-keyvault-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-keyvault-exporter/Chart.yaml
+++ b/charts/azure-keyvault-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-keyvault-exporter
 type: application
 description: A Helm chart for azure-keyvault-exporter
 home: https://github.com/webdevops/azure-keyvault-exporter
-version: 1.0.5
+version: 1.0.6
 # renovate: image=webdevops/azure-keyvault-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-keyvault-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-keyvault-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "azure-keyvault-exporter.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/azure-keyvault-exporter/values.yaml
+++ b/charts/azure-keyvault-exporter/values.yaml
@@ -71,6 +71,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: azure-keyvault-exporter
   labels: {}
   annotations: {}

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.6
+version: 1.0.7
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.5
+version: 1.0.6
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-metrics-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-metrics-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "azure-metrics-exporter.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -71,6 +71,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: azure-metrics-exporter
   labels: {}
   annotations: {}

--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.2.1
+version: 1.2.2
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 23.6.1
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "azure-resourcemanager-exporter.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/azure-resourcemanager-exporter/values.yaml
+++ b/charts/azure-resourcemanager-exporter/values.yaml
@@ -74,6 +74,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: azure-resourcemanager-exporter
   labels: {}
   annotations: {}

--- a/charts/azure-scheduledevents-manager/Chart.yaml
+++ b/charts/azure-scheduledevents-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-scheduledevents-manager
 type: application
 description: A Helm chart for azure-scheduledevents-manager
 home: https://github.com/webdevops/azure-scheduledevents-manager
-version: 1.0.11
+version: 1.0.12
 # renovate: image=webdevops/azure-scheduledevents-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-scheduledevents-manager/templates/serviceaccount.yaml
+++ b/charts/azure-scheduledevents-manager/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "azure-scheduledevents-manager.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/azure-scheduledevents-manager/values.yaml
+++ b/charts/azure-scheduledevents-manager/values.yaml
@@ -65,6 +65,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: azure-scheduledevents-manager
   labels: {}
   annotations: {}

--- a/charts/pagerduty-exporter/Chart.yaml
+++ b/charts/pagerduty-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: pagerduty-exporter
 type: application
 description: A Helm chart for pagerduty-exporter
 home: https://github.com/webdevops/pagerduty-exporter
-version: 1.1.1
+version: 1.1.2
 # renovate: image=webdevops/pagerduty-exporter
 appVersion: 22.12.0
 keywords:

--- a/charts/pagerduty-exporter/templates/serviceaccount.yaml
+++ b/charts/pagerduty-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,4 +15,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "pagerduty-exporter.imagePullSecrets" . | trim | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/pagerduty-exporter/values.yaml
+++ b/charts/pagerduty-exporter/values.yaml
@@ -70,6 +70,7 @@ readinessProbe:
   failureThreshold: 5
 
 serviceAccount:
+  create: true
   name: pagerduty-exporter
   labels: {}
   annotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it

We want to be able to specify a service account to use that has already been created. This was already possible in the azure-loganalytics-exporter chart and support for this had already been added to the `_helper.yaml` files.

I am using managed identity on an AKS cluster to connect to Azure, we have a service account connected to an identity that we want to use, we can however not change the service account to an already existing one in the Helm chart.

#### Special notes for your reviewer

I've bumped the patch version of each chart since the change is mostly backwards compatible. If the user has explicitly changed the serviceAccountName to nil then there service account used changes from default to the fullname of the chart. But in this case Helm would have been trying to create a service account with the name default, which would not work.

Since this touches a lot of different charts I have not added the chart name to the PR title.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
