### PR TITLE
[azure-resourcemanager-exporter] feat: add vpa support

### DIFF
--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.2.2
+version: 1.3.0
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 23.6.1
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/_helpers.tpl
+++ b/charts/azure-resourcemanager-exporter/templates/_helpers.tpl
@@ -41,12 +41,12 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/* Generate basic labels */}}
-{{- define "azure-resourcemanager-exporter.labels" }}
+{{- define "azure-resourcemanager-exporter.labels" -}}
 helm.sh/chart: {{ template "azure-resourcemanager-exporter.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: metrics
 app.kubernetes.io/part-of: {{ template "azure-resourcemanager-exporter.name" . }}
-{{- include "azure-resourcemanager-exporter.selectorLabels" . }}
+{{ include "azure-resourcemanager-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -58,7 +58,7 @@ release: {{ .Release.Name }}
 {{/*
 Selector labels
 */}}
-{{- define "azure-resourcemanager-exporter.selectorLabels" }}
+{{- define "azure-resourcemanager-exporter.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "azure-resourcemanager-exporter.name" . }}
 {{- end }}

--- a/charts/azure-resourcemanager-exporter/templates/configmap.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.existingConfigMap }}
+{{- if not .Values.existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/azure-resourcemanager-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $configmapHash := include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- $secretHash := include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 ---
 apiVersion: apps/v1
@@ -5,7 +6,7 @@ kind: Deployment
 metadata:
   name: {{ template "azure-resourcemanager-exporter.fullname" . }}
   namespace: {{ template "azure-resourcemanager-exporter.namespace" . }}
-  labels: {{ include "azure-resourcemanager-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-resourcemanager-exporter.labels" . | nindent 4 }}
 spec:
   {{- with .Values.replicas }}
   replicas: {{ . }}
@@ -15,22 +16,28 @@ spec:
   {{- end }}
 
   selector:
-    matchLabels: {{- include "azure-resourcemanager-exporter.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "azure-resourcemanager-exporter.selectorLabels" . | nindent 6 }}
 
   minReadySeconds: {{ .minReadySeconds }}
   template:
     metadata:
       labels:
-{{ include "azure-resourcemanager-exporter.selectorLabels" . | indent 8 }}
-{{- with .Values.podLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- include "azure-resourcemanager-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- if or (not .Values.existingConfigMap) (.Values.podAnnotations) (.Values.secrets) }}
       annotations:
+        {{- if not .Values.existingConfigMap }}
+        checksum/config: {{ $configmapHash | quote }}
+        {{- end }}
+        {{- if .Values.secrets }}
         checksum/secret: {{ $secretHash | quote }}
-{{- with .Values.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
-
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | quote }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -62,7 +69,7 @@ spec:
           {{- with .Values.extraEnv }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- if not .Values.config.existingConfigMap }}
+          {{- if not .Values.existingConfigMap }}
             - name: CONFIG
               value: "/config/config.yaml"
           {{- end }}
@@ -102,7 +109,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ .Values.config.existingConfigMap | default (include "azure-resourcemanager-exporter.fullname" .) }}
+            name: {{ .Values.existingConfigMap | default (include "azure-resourcemanager-exporter.fullname" .) }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/azure-resourcemanager-exporter/templates/networkpolicy.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/networkpolicy.yaml
@@ -5,10 +5,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "azure-resourcemanager-exporter.fullname" . }}
   namespace: {{ template "azure-resourcemanager-exporter.namespace" . }}
-  labels: {{ include "azure-resourcemanager-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-resourcemanager-exporter.labels" . | nindent 4 }}
 spec:
   podSelector:
-    matchLabels: {{- include "azure-resourcemanager-exporter.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "azure-resourcemanager-exporter.selectorLabels" . | nindent 6 }}
   policyTypes: {{ toYaml .Values.netpol.policyTypes | nindent 4 }}
   ingress: {{ toYaml .Values.netpol.ingress | nindent 4 }}
   egress: {{ toYaml .Values.netpol.egress | nindent 4 }}

--- a/charts/azure-resourcemanager-exporter/templates/service.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/service.yaml
@@ -23,4 +23,4 @@ spec:
       protocol: TCP
       name: {{ .Values.service.portName }}
       appProtocol: http
-  selector: {{- include "azure-resourcemanager-exporter.selectorLabels" . | nindent 4 }}
+  selector: {{ include "azure-resourcemanager-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/azure-resourcemanager-exporter/templates/verticalpodautoscaler.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ template "azure-resourcemanager-exporter.fullname" . }}
+  namespace: {{ template "azure-resourcemanager-exporter.namespace" . }}
+  labels:
+    {{- include "azure-resourcemanager-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: azure-resourcemanager-exporter
+      {{- with .Values.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ .Values.verticalPodAutoscaler.controlledValues }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.maxAllowed }}
+      maxAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.maxAllowed | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.minAllowed }}
+      minAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.minAllowed | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "azure-resourcemanager-exporter.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/azure-resourcemanager-exporter/values.yaml
+++ b/charts/azure-resourcemanager-exporter/values.yaml
@@ -29,7 +29,7 @@ extraEnv: []
 
 secretsEnableTemplateFunctions: false
 secrets: {}
-# secretName: secretValue
+  # secretName: secretValue
 
 existingConfigMap: ""
 config: {}
@@ -171,6 +171,37 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
+
+# Enable vertical pod autoscaler support
+verticalPodAutoscaler:
+  enabled: false
+
+  # Recommender responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  # recommenders:
+  # - name: custom-recommender-performance
+
+  # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+  controlledResources: []
+  # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+  # controlledValues: RequestsAndLimits
+
+  # Define the max allowed resources for the pod
+  maxAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+  # Define the min allowed resources for the pod
+  minAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+
+  updatePolicy:
+    # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    updateMode: Auto
 
 global:
   imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds support the the vertical pod autoscaler so users do not have to care about the resource usage of the azure-resourcemanager-exporter and let the vertical pod autoscaler to do its job.
Also, fixes invalid value ref to existing config map key and whitespaces in labels.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
