### PR TITLE
[azure-metrics-exporter] feat: add vpa supprt

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.8
+version: 1.1.0
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.7.0
 keywords:

--- a/charts/azure-metrics-exporter/templates/_helpers.tpl
+++ b/charts/azure-metrics-exporter/templates/_helpers.tpl
@@ -41,12 +41,12 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/* Generate basic labels */}}
-{{- define "azure-metrics-exporter.labels" }}
+{{- define "azure-metrics-exporter.labels" -}}
 helm.sh/chart: {{ template "azure-metrics-exporter.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: metrics
 app.kubernetes.io/part-of: {{ template "azure-metrics-exporter.name" . }}
-{{- include "azure-metrics-exporter.selectorLabels" . }}
+{{ include "azure-metrics-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -58,7 +58,7 @@ release: {{ .Release.Name }}
 {{/*
 Selector labels
 */}}
-{{- define "azure-metrics-exporter.selectorLabels" }}
+{{- define "azure-metrics-exporter.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "azure-metrics-exporter.name" . }}
 {{- end }}

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ template "azure-metrics-exporter.fullname" . }}
   namespace: {{ template "azure-metrics-exporter.namespace" . }}
-  labels: {{ include "azure-metrics-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-metrics-exporter.labels" . | nindent 4 }}
 spec:
   {{- with .Values.replicas }}
   replicas: {{ . }}
@@ -15,22 +15,25 @@ spec:
   {{- end }}
 
   selector:
-    matchLabels: {{- include "azure-metrics-exporter.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "azure-metrics-exporter.selectorLabels" . | nindent 6 }}
 
   minReadySeconds: {{ .minReadySeconds }}
   template:
     metadata:
       labels:
-{{ include "azure-metrics-exporter.selectorLabels" . | indent 8 }}
-{{- with .Values.podLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- include "azure-metrics-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or (.Values.podAnnotations) (.Values.secrets) }}
       annotations:
+        {{- if .Values.secrets }}
         checksum/secret: {{ $secretHash | quote }}
-{{- with .Values.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
-
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | quote }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/charts/azure-metrics-exporter/templates/networkpolicy.yaml
+++ b/charts/azure-metrics-exporter/templates/networkpolicy.yaml
@@ -5,10 +5,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "azure-metrics-exporter.fullname" . }}
   namespace: {{ template "azure-metrics-exporter.namespace" . }}
-  labels: {{ include "azure-metrics-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-metrics-exporter.labels" . | nindent 4 }}
 spec:
   podSelector:
-    matchLabels: {{- include "azure-metrics-exporter.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "azure-metrics-exporter.selectorLabels" . | nindent 6 }}
   policyTypes: {{ toYaml .Values.netpol.policyTypes | nindent 4 }}
   ingress: {{ toYaml .Values.netpol.ingress | nindent 4 }}
   egress: {{ toYaml .Values.netpol.egress | nindent 4 }}

--- a/charts/azure-metrics-exporter/templates/verticalpodautoscaler.yaml
+++ b/charts/azure-metrics-exporter/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ template "azure-metrics-exporter.fullname" . }}
+  namespace: {{ template "azure-metrics-exporter.namespace" . }}
+  labels:
+    {{- include "azure-metrics-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: azure-metrics-exporter
+      {{- with .Values.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ .Values.verticalPodAutoscaler.controlledValues }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.maxAllowed }}
+      maxAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.maxAllowed | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.minAllowed }}
+      minAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.minAllowed | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "azure-metrics-exporter.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -242,5 +242,36 @@ prometheus:
 #          timespan: [PT1M]
 #          aggregation: [average, total]
 
+# Enable vertical pod autoscaler support
+verticalPodAutoscaler:
+  enabled: false
+
+  # Recommender responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  # recommenders:
+  # - name: custom-recommender-performance
+
+  # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+  controlledResources: []
+  # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+  # controlledValues: RequestsAndLimits
+
+  # Define the max allowed resources for the pod
+  maxAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+  # Define the min allowed resources for the pod
+  minAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+
+  updatePolicy:
+    # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    updateMode: Auto
+
 global:
   imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds support the the vertical pod autoscaler so users do not have to care about the resource usage of the azure-metrics-exporter and let the vertical pod autoscaler to do its job.
Also, fixes whitespaces in labels.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
