### PR TITLE
[azure-resourcegraph-exporter] feat: add vpa supprt

### DIFF
--- a/charts/azure-resourcegraph-exporter/Chart.yaml
+++ b/charts/azure-resourcegraph-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcegraph-exporter
 type: application
 description: A Helm chart for azure-resourcegraph-exporter
 home: https://github.com/webdevops/azure-resourcegraph-exporter
-version: 1.0.3
+version: 1.1.0
 # renovate: image=webdevops/azure-resourcegraph-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-resourcegraph-exporter/templates/_helpers.tpl
+++ b/charts/azure-resourcegraph-exporter/templates/_helpers.tpl
@@ -40,12 +40,12 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/* Generate basic labels */}}
-{{- define "azure-resourcegraph-exporter.labels" }}
+{{- define "azure-resourcegraph-exporter.labels" -}}
 helm.sh/chart: {{ template "azure-resourcegraph-exporter.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: metrics
 app.kubernetes.io/part-of: {{ template "azure-resourcegraph-exporter.name" . }}
-{{- include "azure-resourcegraph-exporter.selectorLabels" . }}
+{{ include "azure-resourcegraph-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -57,7 +57,7 @@ release: {{ .Release.Name }}
 {{/*
 Selector labels
 */}}
-{{- define "azure-resourcegraph-exporter.selectorLabels" }}
+{{- define "azure-resourcegraph-exporter.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/name: {{ template "azure-resourcegraph-exporter.name" . }}
 {{- end }}

--- a/charts/azure-resourcegraph-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/deployment.yaml
@@ -28,12 +28,18 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or (not .Values.config.existingConfigMap) (.Values.podAnnotations) (.Values.secrets) }}
       annotations:
+        {{- if not .Values.config.existingConfigMap }}
         checksum/config: {{ $configHash | quote }}
+        {{- end }}
+        {{- if .Values.secrets }}
         checksum/secret: {{ $secretHash | quote }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "azure-resourcegraph-exporter.serviceAccountName" . }}
       {{- with .Values.priorityClassName }}

--- a/charts/azure-resourcegraph-exporter/templates/verticalpodautoscaler.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ template "azure-resourcegraph-exporter.fullname" . }}
+  namespace: {{ template "azure-resourcegraph-exporter.namespace" . }}
+  labels:
+    {{- include "azure-resourcegraph-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: azure-resourcegraph-exporter
+      {{- with .Values.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ .Values.verticalPodAutoscaler.controlledValues }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.maxAllowed }}
+      maxAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.maxAllowed | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.minAllowed }}
+      minAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.minAllowed | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "azure-resourcegraph-exporter.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/azure-resourcegraph-exporter/values.yaml
+++ b/charts/azure-resourcegraph-exporter/values.yaml
@@ -221,3 +221,34 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
+
+# Enable vertical pod autoscaler support
+verticalPodAutoscaler:
+  enabled: false
+
+  # Recommender responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  # recommenders:
+  # - name: custom-recommender-performance
+
+  # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+  controlledResources: []
+  # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+  # controlledValues: RequestsAndLimits
+
+  # Define the max allowed resources for the pod
+  maxAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+  # Define the min allowed resources for the pod
+  minAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+
+  updatePolicy:
+    # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    updateMode: Auto


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds support the the vertical pod autoscaler so users do not have to care about the resource usage of the azure-resourcegraph-exporter and let the vertical pod autoscaler to do its job.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
