### PR TITLE
[azure-loganalytics-exporter] Fix ServiceMonitor

### DIFF
--- a/charts/azure-loganalytics-exporter/Chart.yaml
+++ b/charts/azure-loganalytics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-loganalytics-exporter
 type: application
 description: A Helm chart for azure-loganalytics-exporter
 home: https://github.com/webdevops/azure-loganalytics-exporter
-version: 1.0.3
+version: 1.0.4
 # renovate: image=webdevops/azure-loganalytics-exporter
 appVersion: 23.6.0
 keywords:

--- a/charts/azure-loganalytics-exporter/templates/prometheus/servicemonitor.yaml
+++ b/charts/azure-loganalytics-exporter/templates/prometheus/servicemonitor.yaml
@@ -62,7 +62,7 @@ spec:
       params:
         {{ tpl (toYaml $moduleOptions.params) $ | nindent 8 }}
       {{- end }}
-    {{- else }}
+    {{- else if $moduleOptions.params }}
         {{ toYaml $moduleOptions.params | nindent 8 }}
     {{- end }}
     {{- with $.Values.prometheus.monitor.basicAuth }}
@@ -97,9 +97,9 @@ spec:
         {{- . | nindent 8 }}
     {{- end }}
   {{- end }}
+{{- end }}
   {{- with .Values.prometheus.monitor.targetLabels }}
   targetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes issue when ServiceMonitor is enabled

#### Which issue this PR fixes

- fixes #31

#### Special notes for your reviewer

@mblaschke please review as currently azure-loganalytics-exporter chart can't be used

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
