### PR TITLE
[charts/azure-metrics-exporter] add additional labels and annotations

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.9
+version: 1.0.10
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.7.0
 keywords:

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.0.8
+version: 1.0.9
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 23.7.0
 keywords:

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -5,9 +5,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- with .Values.prometheus.monitor.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "azure-metrics-exporter.fullname" $root }}-{{ .name }}
   namespace: {{ template "azure-metrics-exporter.namespace" $root }}
-  labels: {{ include "azure-metrics-exporter.labels" $root | indent 4 }}
+  labels: 
+    {{ include "azure-metrics-exporter.labels" $root | indent 4 }}
+    {{- with .Values.prometheus.monitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" $monitorDefaults.jobLabel }}
   {{ include "servicemonitor.scrapeLimits" $monitorDefaults | indent 2 }}

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -6,8 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   {{- with .Values.prometheus.monitor.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "azure-metrics-exporter.fullname" $root }}-{{ .name }}
   namespace: {{ template "azure-metrics-exporter.namespace" $root }}

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.yaml
@@ -4,8 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   {{- with .Values.prometheus.monitor.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "azure-metrics-exporter.fullname" . }}
   namespace: {{ template "azure-metrics-exporter.namespace" . }}

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.yaml
@@ -3,9 +3,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- with .Values.prometheus.monitor.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "azure-metrics-exporter.fullname" . }}
   namespace: {{ template "azure-metrics-exporter.namespace" . }}
   labels: {{ include "azure-metrics-exporter.labels" . | indent 4 }}
+    {{- with .Values.prometheus.monitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -135,6 +135,9 @@ prometheus:
 
     jobLabel: ""
 
+    additionalAnnotations: {}
+    additionalLabels: {}
+
     scheme: http
     basicAuth: {}
     bearerTokenFile:


### PR DESCRIPTION
#### What this PR does / why we need it
The azure-metrics-exporter chart does not has the ability to include additional labels and annotations to the servicemonitors, which other charts do have, like the azure-loganalytics-exporter. 

#### Which issue this PR fixes

None

#### Special notes for your reviewer
Used the same approach/format as azure-loganalytics-exporter chart

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
