### PR TITLE
[azure-resourcemanager-exporter] fix podLabels annotation in 1.30.0

### DIFF
--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.3.0
+version: 1.3.1
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 23.6.1
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         {{- include "azure-resourcemanager-exporter.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- if or (not .Values.existingConfigMap) (.Values.podAnnotations) (.Values.secrets) }}
       annotations:


### PR DESCRIPTION
#### What this PR does / why we need it

Since **azure-resourcemanager-exporter-1.3.0** the podLabels annotation isn't working anymore

#### Which issue this PR fixes

- fixes issue #43 


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
