### PR TITLE
[azure-metrics-exporter]: fix broken servicemonitor.metricprobe.yaml

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.6
+version: 1.2.7
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -20,13 +20,13 @@ spec:
   {{ include "servicemonitor.scrapeLimits" $monitorDefaults | indent 2 }}
   selector:
     matchLabels: {{- include "azure-metrics-exporter.selectorLabels" $root | nindent 6 }}
-  {{- if .Values.prometheus.monitor.namespaceSelector }}
-  namespaceSelector: {{ toYaml .Values.prometheus.monitor.namespaceSelector | nindent 4 }}
+  {{- if $root.Values.prometheus.monitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml $root.Values.prometheus.monitor.namespaceSelector | nindent 4 }}
   {{- else }}
   namespaceSelector:
     matchNames:
       - {{ template "azure-metrics-exporter.namespace" . }}
-  {{- end }} 
+  {{- end }}
   endpoints:
     - port: {{ $root.Values.service.portName }}
       scheme: {{ (default $monitorDefaults.scheme .scheme) }}


### PR DESCRIPTION
#### What this PR does / why we need it

This fixes the invalid condition (to check for namespaceSelector) that prevents template from rendering.

i.e. When probes exist, the template no longer renders as shown below

```
Error: template: azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml:23:16: executing "azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml" at <.Values.prometheus.monitor.namespaceSelector>: nil pointer evaluating interface {}.prometheus
```


#### Which issue this PR fixes

- fixes issue caused by https://github.com/webdevops/helm-charts/pull/56

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
