### PR TITLE
[azure-resourcegraph-exporter]` fix servicemonitor yaml formatting error#63

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.6
+version: 1.2.7
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-resourcegraph-exporter/templates/prometheus/servicemonitor.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/prometheus/servicemonitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "azure-resourcegraph-exporter.fullname" . }}
   namespace: {{ template "azure-resourcegraph-exporter.namespace" . }}
-  labels: {{ include "azure-resourcegraph-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-resourcegraph-exporter.labels" . | nindent 4 }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | nindent 2 }}


### PR DESCRIPTION
#### What this PR does / why we need it

- fixes #
https://github.com/webdevops/helm-charts/issues/63

#### Special notes for your reviewer

This is just a quick fix. Do you prefer the same style as in azure-metrics-exporter:
``` helm
  labels:
    {{ include "azure-metrics-exporter.labels" . | nindent 4 }}
    {{- with .Values.prometheus.monitor.additionalLabels }}
    {{- toYaml . | nindent 4 }}
    {{- end }}
```
If, please let me know and i will create a new PR. 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
