### PR TITLE
azure-metrics-exporter: Fix scope passed to azure-metrics-exporter.namespace helper

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.8
+version: 1.2.9
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -25,7 +25,7 @@ spec:
   {{- else }}
   namespaceSelector:
     matchNames:
-      - {{ template "azure-metrics-exporter.namespace" . }}
+      - {{ template "azure-metrics-exporter.namespace" $root }}
   {{- end }}
   endpoints:
     - port: {{ $root.Values.service.portName }}


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes passing the wrong scope to a helper function. The regression was introduced in https://github.com/webdevops/helm-charts/commit/32bcdf88964677006df1add417164112420f9e27#diff-aa56b5dd17b4f1219c20ec358aa64031403588be6582a00c1256f2eb3176d772R28 and only partially addressed in https://github.com/webdevops/helm-charts/pull/62

#### Which issue this PR fixes

- fixes #60

#### Special notes for your reviewer

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
