### PR TITLE
[azure-resourcemanager-exporter]` fix servicemonitor yaml formatting error#70

### DIFF
--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.3.4
+version: 1.3.5
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 24.9.0
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/prometheus/servicemonitor.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/prometheus/servicemonitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "azure-resourcemanager-exporter.fullname" . }}
   namespace: {{ template "azure-resourcemanager-exporter.namespace" . }}
-  labels: {{ include "azure-resourcemanager-exporter.labels" . | indent 4 }}
+  labels: {{ include "azure-resourcemanager-exporter.labels" . | nindent 4 }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}


### PR DESCRIPTION
#### What this PR does / why we need it
The ServiceMonitor for azure-resourcemanager-exporter is not working.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #70 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Chart Version bumped
- [ ]x Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
