### PR TITLE
azure-metrics-exporter: fix support for imagePullSecrets

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.8
+version: 1.2.9
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -92,3 +92,7 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}

--- a/charts/azure-metrics-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-metrics-exporter/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-metrics-exporter.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -101,6 +101,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -279,6 +280,3 @@ verticalPodAutoscaler:
     # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     updateMode: Auto
-
-global:
-  imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it

It adds support for `imagePullSecrets` in case Docker Hub credentials are used to avoid hitting API rate limits. Or in case a private registry cache/mirror with authentication is used. 

There were some bits of code around it, but not working as reported in #72

#### Which issue this PR fixes

- fixes #72

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
