### PR TITLE
[azure-metrics-exporter] Support extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.8
+version: 1.3.0
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
             - containerPort: 8080
               name: http-metrics
               protocol: TCP
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
 
 {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -91,4 +95,8 @@ spec:
 {{- end }}
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -32,6 +32,18 @@ secretsEnableTemplateFunctions: false
 secrets: {}
 # secretName: secretValue
 
+extraVolumes: []
+  # - name: azure-identity-token
+  #   projected:
+  #     sources:
+  #       - serviceAccountToken:
+  #         audience: api://AzureADTokenExchange
+  #         expirationSeconds: 3600
+  #         path: federated-token
+extraVolumeMounts: []
+  # - mountPath: /var/run/secrets/azure/tokens
+  #   name: azure-identity-token
+  #   readOnly: true
 
 resources:
   limits:


### PR DESCRIPTION
#### What this PR does / why we need it

Enables adding volumes and volumeMounts to azure-metrics-exporter pod which is useful when using workload identity (as described in https://github.com/Azure-Samples/azure-ad-workload-identity)

#### Which issue this PR fixes

None that I know of

#### Special notes for your reviewer

N/A

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
