### PR TITLE
[azure-metrics-exporter] fix: use root variable for namespace selector in metricprobes

### DIFF
--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.8
+version: 1.2.9
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
+++ b/charts/azure-metrics-exporter/templates/prometheus/servicemonitor.metricprobe.yaml
@@ -25,7 +25,7 @@ spec:
   {{- else }}
   namespaceSelector:
     matchNames:
-      - {{ template "azure-metrics-exporter.namespace" . }}
+      - {{ template "azure-metrics-exporter.namespace" $root }}
   {{- end }}
   endpoints:
     - port: {{ $root.Values.service.portName }}


### PR DESCRIPTION
#### What this PR does / why we need it

An error occur when using metricprobes.

```
Error: template: jobs/charts/azure-metrics-exporter/templates/_helpers.tpl:39:16: executing "azure-metrics-exporter.namespace" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace
helm.go:84: [debug] template: jobs/charts/azure-metrics-exporter/templates/_helpers.tpl:39:16: executing "azure-metrics-exporter.namespace" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`)
