### PR TITLE
fix[all charts]: fix support for imagePullSecrets

### DIFF
--- a/charts/azure-janitor/Chart.yaml
+++ b/charts/azure-janitor/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-janitor
 type: application
 description: A Helm chart for azure-janitor
 home: https://github.com/webdevops/azure-janitor
-version: 1.0.12
+version: 1.0.13
 # renovate: image=webdevops/azure-janitor
 appVersion: 24.9.0
 keywords:

--- a/charts/azure-janitor/templates/deployment.yaml
+++ b/charts/azure-janitor/templates/deployment.yaml
@@ -87,3 +87,6 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}

--- a/charts/azure-janitor/templates/serviceaccount.yaml
+++ b/charts/azure-janitor/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-janitor.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-janitor/values.yaml
+++ b/charts/azure-janitor/values.yaml
@@ -104,6 +104,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -173,6 +174,3 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
-
-global:
-  imagePullSecrets: []

--- a/charts/azure-keyvault-exporter/Chart.yaml
+++ b/charts/azure-keyvault-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-keyvault-exporter
 type: application
 description: A Helm chart for azure-keyvault-exporter
 home: https://github.com/webdevops/azure-keyvault-exporter
-version: 1.0.11
+version: 1.0.12
 # renovate: image=webdevops/azure-keyvault-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-keyvault-exporter/templates/deployment.yaml
+++ b/charts/azure-keyvault-exporter/templates/deployment.yaml
@@ -89,3 +89,6 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}

--- a/charts/azure-keyvault-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-keyvault-exporter/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-keyvault-exporter.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-keyvault-exporter/values.yaml
+++ b/charts/azure-keyvault-exporter/values.yaml
@@ -101,6 +101,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -170,6 +171,3 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
-
-global:
-  imagePullSecrets: []

--- a/charts/azure-loganalytics-exporter/Chart.yaml
+++ b/charts/azure-loganalytics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-loganalytics-exporter
 type: application
 description: A Helm chart for azure-loganalytics-exporter
 home: https://github.com/webdevops/azure-loganalytics-exporter
-version: 1.0.11
+version: 1.0.12
 # renovate: image=webdevops/azure-loganalytics-exporter
 appVersion: 25.5.0
 keywords:

--- a/charts/azure-loganalytics-exporter/README.md
+++ b/charts/azure-loganalytics-exporter/README.md
@@ -30,7 +30,7 @@ A Helm chart for azure-loganalytics-exporter
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` | String to fully override azure-loganalytics-exporter.fullname template |
-| global.imagePullSecrets | list | `[]` | registry secret names as an array |
+| imagePullSecrets | list | `[]` | registry secret names as an array |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` | image registry |
 | image.repository | string | `"webdevops/azure-loganalytics-exporter"` | image repository |

--- a/charts/azure-loganalytics-exporter/templates/deployment.yaml
+++ b/charts/azure-loganalytics-exporter/templates/deployment.yaml
@@ -108,3 +108,6 @@ spec:
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}

--- a/charts/azure-loganalytics-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-loganalytics-exporter/templates/serviceaccount.yaml
@@ -14,8 +14,4 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- with .Values.global.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-loganalytics-exporter/values.yaml
+++ b/charts/azure-loganalytics-exporter/values.yaml
@@ -1,8 +1,4 @@
 ---
-global:
-  # -- registry secret names as an array
-  imagePullSecrets: []
-
 # -- String to partially override azure-loganalytics-exporter.fullname template (will maintain the release name)
 nameOverride: ''
 
@@ -143,6 +139,10 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
+
+# -- registry secret names as an array
+imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP

--- a/charts/azure-metrics-exporter/Chart.yaml
+++ b/charts/azure-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-metrics-exporter
 type: application
 description: A Helm chart for azure-metrics-exporter
 home: https://github.com/webdevops/azure-metrics-exporter
-version: 1.2.9
+version: 1.2.10
 # renovate: image=webdevops/azure-metrics-exporter
 appVersion: 24.9.1
 keywords:

--- a/charts/azure-metrics-exporter/templates/deployment.yaml
+++ b/charts/azure-metrics-exporter/templates/deployment.yaml
@@ -92,3 +92,6 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}

--- a/charts/azure-metrics-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-metrics-exporter/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-metrics-exporter.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-metrics-exporter/values.yaml
+++ b/charts/azure-metrics-exporter/values.yaml
@@ -101,6 +101,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -279,6 +280,3 @@ verticalPodAutoscaler:
     # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     updateMode: Auto
-
-global:
-  imagePullSecrets: []

--- a/charts/azure-resourcegraph-exporter/Chart.yaml
+++ b/charts/azure-resourcegraph-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcegraph-exporter
 type: application
 description: A Helm chart for azure-resourcegraph-exporter
 home: https://github.com/webdevops/azure-resourcegraph-exporter
-version: 1.1.4
+version: 1.1.5
 # renovate: image=webdevops/azure-resourcegraph-exporter
 appVersion: 24.9.0
 keywords:

--- a/charts/azure-resourcegraph-exporter/README.md
+++ b/charts/azure-resourcegraph-exporter/README.md
@@ -30,7 +30,7 @@ A Helm chart for azure-resourcegraph-exporter
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` | String to fully override azure-resourcegraph-exporter.fullname template |
-| global.imagePullSecrets | list | `[]` | registry secret names as an array |
+| imagePullSecrets | list | `[]` | registry secret names as an array |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` | image registry |
 | image.repository | string | `"webdevops/azure-resourcegraph-exporter"` | image repository |

--- a/charts/azure-resourcegraph-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/deployment.yaml
@@ -114,3 +114,6 @@ spec:
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}

--- a/charts/azure-resourcegraph-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-resourcegraph-exporter/templates/serviceaccount.yaml
@@ -14,8 +14,4 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- with .Values.global.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-resourcegraph-exporter/values.yaml
+++ b/charts/azure-resourcegraph-exporter/values.yaml
@@ -1,8 +1,4 @@
 ---
-global:
-  # -- registry secret names as an array
-  imagePullSecrets: []
-
 # -- String to partially override azure-resourcegraph-exporter.fullname template (will maintain the release name)
 nameOverride: ''
 
@@ -147,6 +143,10 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
+
+# -- registry secret names as an array
+imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP

--- a/charts/azure-resourcemanager-exporter/Chart.yaml
+++ b/charts/azure-resourcemanager-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-resourcemanager-exporter
 type: application
 description: A Helm chart for azure-resourcemanager-exporter
 home: https://github.com/webdevops/azure-resourcemanager-exporter
-version: 1.3.4
+version: 1.3.5
 # renovate: image=webdevops/azure-resourcemanager-exporter
 appVersion: 24.9.0
 keywords:

--- a/charts/azure-resourcemanager-exporter/templates/deployment.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/deployment.yaml
@@ -106,6 +106,9 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/azure-resourcemanager-exporter/templates/secret.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/secret.yaml
@@ -6,7 +6,8 @@ type: Opaque
 metadata:
   name: {{ template "azure-resourcemanager-exporter.fullname" . }}
   namespace: {{ template "azure-resourcemanager-exporter.namespace" . }}
-  labels: {{ include "azure-resourcemanager-exporter.labels" . | indent 4 }}
+  labels:
+    {{- include "azure-resourcemanager-exporter.labels" . | nindent 4 }}
 data:
 {{- range $index, $val := .Values.secrets }}
   {{- if $.Values.secretsEnableTemplateFunctions }}

--- a/charts/azure-resourcemanager-exporter/templates/serviceaccount.yaml
+++ b/charts/azure-resourcemanager-exporter/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-resourcemanager-exporter.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-resourcemanager-exporter/values.yaml
+++ b/charts/azure-resourcemanager-exporter/values.yaml
@@ -104,6 +104,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -204,6 +205,3 @@ verticalPodAutoscaler:
     # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     updateMode: Auto
-
-global:
-  imagePullSecrets: []

--- a/charts/azure-scheduledevents-manager/Chart.yaml
+++ b/charts/azure-scheduledevents-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: azure-scheduledevents-manager
 type: application
 description: A Helm chart for azure-scheduledevents-manager
 home: https://github.com/webdevops/azure-scheduledevents-manager
-version: 1.0.16
+version: 1.0.17
 # renovate: image=webdevops/azure-scheduledevents-exporter
 appVersion: 24.9.0
 keywords:

--- a/charts/azure-scheduledevents-manager/templates/daemonset.yaml
+++ b/charts/azure-scheduledevents-manager/templates/daemonset.yaml
@@ -99,3 +99,6 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}

--- a/charts/azure-scheduledevents-manager/templates/serviceaccount.yaml
+++ b/charts/azure-scheduledevents-manager/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "azure-scheduledevents-manager.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/azure-scheduledevents-manager/values.yaml
+++ b/charts/azure-scheduledevents-manager/values.yaml
@@ -98,6 +98,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 scheduledEvent:
   approve: true
@@ -194,6 +195,3 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
-
-global:
-  imagePullSecrets: []

--- a/charts/kube-pool-manager/Chart.yaml
+++ b/charts/kube-pool-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: kube-pool-manager
 type: application
 description: A Helm chart for kube-pool-manager
 home: https://github.com/webdevops/kube-pool-manager
-version: 1.0.15
+version: 1.0.16
 # renovate: image=webdevops/kube-pool-manager
 appVersion: 24.9.0
 keywords:

--- a/charts/kube-pool-manager/templates/deployment.yaml
+++ b/charts/kube-pool-manager/templates/deployment.yaml
@@ -113,7 +113,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/kube-pool-manager/templates/serviceaccount.yaml
+++ b/charts/kube-pool-manager/templates/serviceaccount.yaml
@@ -11,7 +11,3 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "kube-pool-manager.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}

--- a/charts/kube-pool-manager/values.yaml
+++ b/charts/kube-pool-manager/values.yaml
@@ -103,6 +103,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -175,6 +176,3 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
-
-global:
-  imagePullSecrets: []

--- a/charts/pagerduty-exporter/Chart.yaml
+++ b/charts/pagerduty-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: pagerduty-exporter
 type: application
 description: A Helm chart for pagerduty-exporter
 home: https://github.com/webdevops/pagerduty-exporter
-version: 1.1.6
+version: 1.1.7
 # renovate: image=webdevops/pagerduty-exporter
 appVersion: 24.9.0
 keywords:

--- a/charts/pagerduty-exporter/templates/deployment.yaml
+++ b/charts/pagerduty-exporter/templates/deployment.yaml
@@ -89,3 +89,6 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:  {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}

--- a/charts/pagerduty-exporter/templates/serviceaccount.yaml
+++ b/charts/pagerduty-exporter/templates/serviceaccount.yaml
@@ -12,8 +12,4 @@ metadata:
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{ include "pagerduty-exporter.imagePullSecrets" . | trim | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/pagerduty-exporter/values.yaml
+++ b/charts/pagerduty-exporter/values.yaml
@@ -100,6 +100,7 @@ containerSecurityContext:
 
 # -- registry secret names as an array
 imagePullSecrets: []
+  # - name: pull-secret-name
 
 service:
   type: ClusterIP
@@ -169,6 +170,3 @@ prometheus:
     ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
     ##
     labelValueLengthLimit: 0
-
-global:
-  imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it

This PR supersedes #78, because the support for `imagePullSecrets` was broken in the same way for all of the charts

#### Which issue this PR fixes

Should fix issue #72.
Documentation and examples in `values.yaml` updated where applicable.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Versions bumped
- [ ] Title of the PR starts with chart name (e.g. `[azure-metrics-exporter]`) <-- does not apply
